### PR TITLE
docs: add repository README and revise serato guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# DJ Tools
+
+A small collection of utilities for working with DJ software.
+
+- `mixxx-tracklist-extractor/` – export a tracklist from Mixxx's history playlist.
+- `serato-crates-usb-export/` – export Serato crates to a USB drive and copy the `_Serato_` folder.
+
+See each subdirectory for more details.

--- a/serato-crates-usb-export/README.md
+++ b/serato-crates-usb-export/README.md
@@ -1,10 +1,8 @@
-Serato Crate Export Script
-==========================
+# Serato Crate Export Script
 
-This script automates exporting selected Serato crates to a USB drive using `serato_tools` and the `serato_usb_export` CLI.
+This script exports selected Serato crates to a USB drive using `serato_tools` and the `serato_usb_export` CLI, then copies the entire `_Serato_` folder to the same drive.
 
-Requirements
-------------
+## Requirements
 
 - Python 3.8+
 - serato-tools (for crate handling)
@@ -12,46 +10,32 @@ Requirements
 
 Install them with:
 
-    pip install serato-tools serato-usb-export
+```bash
+pip install serato-tools serato-usb-export
+```
 
-What the script does
---------------------
+## What the script does
 
 1. Reads all available `.crate` files from your Serato library (`Crate.list_dir()`).
 2. Formats crate names into `*Crate Name*` format expected by `serato_usb_export`.
 3. Filters out unwanted crates (e.g. `*Recorded*`).
 4. Runs `serato_usb_export` with the selected crates, exporting them to your USB drive.
+5. Copies the `_Serato_` folder from your user profile to the USB drive, replacing any existing copy.
 
-Example command generated:
+## Usage
 
-    serato_usb_export --drive d --crate_matcher *Bassline* *Techno Acid* *Techno High* ... --root_crate="Ido's Music"
+1. Run the script:
 
-Usage
------
+```bash
+python export.py
+```
 
-1. Save the script as `export.py` (or whatever name you prefer).
-2. Plug in your USB drive (e.g. `D:`).
-3. Run the script from PowerShell or CMD:
+2. Enter the root crate name when prompted (required).
+3. Enter the USB drive letter when prompted (press Enter for `d`).
 
-    python export.py
+The script prints the command it runs and reports when the `_Serato_` folder has been copied.
 
-By default:
-- USB drive is `d`
-- Root crate is `"Ido's Music"`
+## Notes
 
-Customization
--------------
-
-You can change the defaults at the bottom of the script:
-
-    if __name__ == "__main__":
-        run_export(drive="e", root_crate="My USB Crate")
-
-- Change `drive="d"` to match your USB drive letter.
-- Change `root_crate="Ido's Music"` to your preferred root crate name.
-
-Notes
------
-
-- The script **excludes** the crate `*Recorded*` automatically.
-- You can add more filters in the `format_crates()` function if needed (e.g. to skip `*Serato Stems*`).
+- The script excludes the crate `*Recorded*` automatically.
+- To hard‑code defaults instead of interactive prompts, modify the `if __name__ == "__main__"` block.


### PR DESCRIPTION
## Summary
- Add top-level README describing available DJ utilities
- Update Serato crate export README to reflect current script behavior

## Testing
- `python -m py_compile serato-crates-usb-export/export.py mixxx-tracklist-extractor/tracklist_exporter.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfc2b10664832f9cad1d0d497e4785